### PR TITLE
Fixed pysam

### DIFF
--- a/ChromoSeqReporter.hg38.pl
+++ b/ChromoSeqReporter.hg38.pl
@@ -352,7 +352,7 @@ while(<F>){
     chomp;
     my @F = split("\t",$_);
 
-    splice(@F,6,4);
+#    splice(@F,6,4);
 
     next if $F[10]=~/synonymous|UTR|stream/ || $F[5] eq 'FilteredInAll';
     

--- a/Chromoseq_basespace.v9.wdl
+++ b/Chromoseq_basespace.v9.wdl
@@ -400,7 +400,8 @@ task combine_variants {
   command {
     /usr/bin/java -Xmx8g -jar /opt/GenomeAnalysisTK.jar -T CombineVariants -R ${refFasta} --variant:varscanIndel ${VarscanIndel} \
     --variant:varscanSNV ${VarscanSNV} --variant:PindelITD ${PindelITD} -o /tmp/out.vcf --genotypemergeoption UNIQUIFY && \
-    /usr/bin/java -Xmx16g -jar /opt/GenomeAnalysisTK.jar -T LeftAlignAndTrimVariants -R ${refFasta} --variant /tmp/out.vcf -o ${Name}.combined_tagged.vcf
+    /usr/bin/java -Xmx16g -jar /opt/GenomeAnalysisTK.jar -T LeftAlignAndTrimVariants -R ${refFasta} --variant /tmp/out.vcf -o /tmp/combined.vcf && \
+    /opt/conda/bin/python /usr/local/bin/addReadCountsToVcfCRAM.py -r ${refFasta} /tmp/combined.vcf ${Bam} ${Name} > ${Name}.combined_tagged.vcf
   }
   output {
     File combined_vcf_file = "${Name}.combined_tagged.vcf"
@@ -429,7 +430,7 @@ task annotate_variants {
     /usr/bin/java -Xmx4g -jar /opt/GenomeAnalysisTK.jar -T VariantsToTable \
     -R ${refFasta} --variant ${Name}.annotated_filtered.vcf.gz -o ${Name}.variants.tsv \
     -F CHROM -F POS -F ID -F REF -F ALT -F set \
-    -GF GT -GF RD -GF AD -GF FREQ && \
+    -GF GT -GF NR -GF NV -GF VAF && \
     /opt/conda/envs/python2/bin/python /usr/local/bin/add_annotations_to_table_helper.py ${Name}.variants.tsv ${Name}.annotated_filtered.vcf.gz Consequence,SYMBOL,Feature_type,Feature,HGVSc,HGVSp,cDNA_position,CDS_position,Protein_position,Amino_acids,Codons,HGNC_ID,gnomAD_AF,gnomAD_AFR_AF,gnomAD_AMR_AF,gnomAD_ASJ_AF,gnomAD_EAS_AF,gnomAD_FIN_AF,gnomAD_NFE_AF,gnomAD_OTH_AF,gnomAD_SAS_AF,CLIN_SIG,SOMATIC,PHENO ./ && \
     mv variants.annotated.tsv ${Name}.variants_annotated.tsv; else touch ${Name}.variants_annotated.tsv; fi
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dhspence/docker-genomic-analysis:latest
+FROM dhspence/docker-genomic-analysis:5
 MAINTAINER David H. Spencer <dspencer@wustl.edu>
 
 LABEL description="Heavy container for Chromoseq"

--- a/addReadCountsToVcfCRAM.py
+++ b/addReadCountsToVcfCRAM.py
@@ -22,7 +22,7 @@ mysample = args.samplename
 # open vcf file
 vcffile = pysam.VariantFile(args.vcffile)
 # open bam file
-samfile = pysam.AlignmentFile(args.cramfile,"rc")
+samfile = pysam.AlignmentFile(args.cramfile,"rc",reference_filename=args.reference)
 # open reffasta
 fa = pysam.FastaFile(args.reference)
 
@@ -43,8 +43,9 @@ for rec in vcffile.fetch():
 
     # if the variant is a substitution
     if len(rec.ref) == len(rec.alts[0]) and len(rec.ref) == 1:
-        
-        for pileup in samfile.pileup(rec.contig, rec.pos-1, rec.pos):            
+
+        for pileup in samfile.pileup(rec.contig, rec.pos-1, rec.pos):
+
             if pileup.pos == rec.pos-1: # only consider the variant position
 
                 for read in pileup.pileups:
@@ -72,7 +73,8 @@ for rec in vcffile.fetch():
         else: # if insertion
             altseq = altseq + rec.alts[0] + fa.fetch(rec.contig,rec.pos,rec.pos+window)
 
-        for pileup in samfile.pileup(rec.contig, rec.pos-1, rec.pos):
+        pu = samfile.pileup(rec.contig, rec.pos-1, rec.pos, multiple_iterators = False)
+        for pileup in pu:
             if pileup.pos == rec.pos-1:
                 for read in pileup.pileups:
 


### PR DESCRIPTION
Compiled a fork of pysam that fixed the issue in addreadcountstovcfcram.py. This new version is in the source docker container that tagged '5'. Also added explicit refseq fasta argument to the open cram function in this script and reverted some other changes related to this fix. This all needs to be tested to make sure it works.